### PR TITLE
debug Surface definition

### DIFF
--- a/twodanalysis/BioPolymer2D.py
+++ b/twodanalysis/BioPolymer2D.py
@@ -163,7 +163,7 @@ class BioPolymer2D:
 
         if not surf_selection is None:
             if isinstance(surf_selection, str):
-                self.surf_pos=self.getPositions(select=surf_selection,inplace=False,surf_is_zero=False).mean(axis=(0,1)) #If want mean only over atoms set axis=1
+                self.surf_pos=self.getPositions(select=surf_selection,inplace=False,surf_is_zero=False,pos_type='all').mean(axis=(0,1)) #If want mean only over atoms set axis=1
                 print(' Mean position of the surface is', self.surf_pos)
             else:
                 raise TypeError("`surf_selection` must be a string and a valid MDAnalysis selection")


### PR DESCRIPTION
<!-- Does this PR fix an issue or relate to an existing discussion? Please link it below after "Fixes #" -->

Fixes #
Bug:
When defining the surface, the distances were computed using the COM of the whole residues of the selected atoms. 

FIX:

Now it only considers the positioning of the atoms, selected only to compute the surface position. 

Changes made in this Pull Request:
<!-- Summarise changes made with dot points below -->
 - 
 - 


PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?
